### PR TITLE
Add documentation for PotionTracker analysis and Classic Era addon fundamentals

### DIFF
--- a/docs/REPO_ANALYSIS.md
+++ b/docs/REPO_ANALYSIS.md
@@ -1,0 +1,45 @@
+# PotionTracker Addon Code Walkthrough
+
+## Repository Overview
+PotionTracker is a World of Warcraft Classic Era addon that tracks raid buff and potion usage, records encounter context, and surfaces the collected data through exports and in-game UI panels. The addon is implemented primarily in `PotionTracker.lua`, with a `.toc` manifest describing metadata and embedded libraries for dropdown menus.
+
+## File Structure
+- `PotionTracker.toc` — Addon manifest declaring interface version, metadata, saved variable table, embedded library files, and the main Lua file.
+- `PotionTracker.lua` — Monolithic Lua module that defines the addon frame, event handling, configuration UI, tracking logic, history exports, and slash commands.
+- `Libs/` — Bundled dependencies (LibStub, LibUIDropDownMenu) required for dropdown UI widgets.
+
+## Initialization Flow
+1. A frame is created and subscribes to character login, aura changes, group roster changes, combat state transitions, target updates, and combat log events (`CreateFrame` & `RegisterEvent`).
+2. On `PLAYER_LOGIN`, saved variables are initialized, tracked buff defaults are seeded, logging preferences restored, and the minimap, options, and configuration UIs are created. If tracking was enabled previously, it scans current units immediately (`PLAYER_LOGIN` handler).
+
+## Logging Facilities
+- Log levels (`ERROR`, `WARN`, `INFO`, `DEBUG`) gate chat output. The selected level is stored in `PotionTrackerDB` and reflected in the options UI. `Print`, `Debug`, and `ShouldLog` implement level-aware messaging.
+
+## History Management & Export
+- `buffHistory` retains chronological buff events with throttled retention enforced by a configurable limit.
+- `ExportCSV` builds both a summary CSV (player vs. buff counts) and a detailed CSV (timestamped events, encounter metadata, target snapshots) and stores the strings in saved variables for later retrieval or slash command display.
+
+## Tracking Workflow
+- `ToggleTracking` flips the tracking state, resets caches, and initializes units. Event handlers bail out early when disabled.
+- `InitializeUnitBuffs` scans units to establish baseline buff states to avoid double-counting existing auras when tracking begins.
+- `CheckNewBuffs` compares current buff snapshots against cached state, logging gained/lost events and updating history.
+- Combat detection (`PLAYER_REGEN_DISABLED/ENABLED`) wraps tracked encounters with `COMBAT_START`/`COMBAT_END` records, tracking boss targets defined in `trackedMobs` and storing encounter IDs.
+
+## UI Components
+- **Minimap Button**: A draggable icon toggles tracking and exposes an options dropdown for configuration, exports, and statistics.
+- **Options Panel**: Provides checkboxes, sliders, dropdowns for tracking enablement, history retention, and log level selection. Registered with Interface Options (or new Settings panel when available).
+- **Buff Configuration**: Dialog listing tracked spell IDs grouped by category, allowing players to enable/disable buffs and persist frame position.
+- **Spreadsheet View**: Scrollable table summarizing player buff counts built from saved history and rendered in-game.
+
+## Slash Commands
+`/pt` includes subcommands to toggle tracking, open configuration, export data, clear history, report stats, adjust logging, dump CSV buffers, and open the spreadsheet view.
+
+## Key Data Tables
+- `availableBuffs`: Spell metadata used to seed tracked buffs grouped by categories (e.g., protection potions, world buffs, consumables).
+- `trackedBuffs`: Runtime map of spell IDs to localized names, filtered by user selection and used to map combat log spell IDs to display strings.
+- `trackedMobs`: Lookup table of raid bosses used to enrich combat events and encounter tracking.
+
+## Extensibility Considerations
+- The addon currently stores exports as strings in saved variables; future improvements could include direct file export via Companion apps.
+- UI frames are created programmatically; splitting logic into multiple Lua files or modules would improve maintainability.
+- Additional analytics (uptime percentages, potion cooldown detection) could be derived from existing history data.

--- a/docs/WOW_CLASSIC_ADDON_NOTES.md
+++ b/docs/WOW_CLASSIC_ADDON_NOTES.md
@@ -1,0 +1,38 @@
+# World of Warcraft Classic Era Addon Architecture
+
+## File & Folder Layout
+- Each addon resides in its own folder within `Interface/AddOns/` and is named after the addon (e.g., `PotionTracker`).
+- A `.toc` (Table of Contents) file is required and lists metadata (Interface version, Title, Notes, Author, SavedVariables, Dependencies) followed by the Lua/XML file load order.
+- Lua files contain the executable addon code. XML files are optional and typically used for declarative UI layouts, but Classic Era allows creating frames entirely from Lua, as PotionTracker does.
+- Bundled libraries (e.g., LibStub, LibUIDropDownMenu) live within subfolders and are referenced from the `.toc` so they load before dependent code.
+
+## Loading & Execution Model
+- Addons are loaded when the client starts or when logging into a character if they are enabled. Files listed in the `.toc` are executed sequentially in a single Lua environment shared by all addons.
+- Execution is sandboxed: addons cannot access the operating system directly, perform arbitrary file I/O, or issue network requests. They can only use APIs exposed by Blizzard's UI environment.
+- Event-driven programming is central. Addons create frames, register for events (e.g., `PLAYER_LOGIN`, `UNIT_AURA`, `COMBAT_LOG_EVENT_UNFILTERED`), and implement `OnEvent` handlers to react to game state changes.
+- Secure code paths (taint system) restrict protected actions during combat; Classic Era addons must avoid insecure UI modifications while in combat lockdown unless using secure templates.
+
+## Saved Variables & Persistence
+- The `.toc` `## SavedVariables` line declares global tables that are serialized to disk on logout/reload (`WTF/Account/.../SavedVariables`).
+- Addons initialize these tables during `PLAYER_LOGIN` (or `ADDON_LOADED` in modern patterns) and update them as the player interacts with the addon.
+- Saved variables persist across sessions and can store configuration, historical data, and export payloads, as PotionTracker does.
+
+## User Interaction Patterns
+- Slash commands are registered by assigning handler functions to `SlashCmdList` entries, and the `SLASH_<NAME>1` constants declare command strings (e.g., `/pt`).
+- UI can be built dynamically via `CreateFrame`, textures, font strings, and templates. Classic Era provides premade templates like `UIDropDownMenuTemplate`, `OptionsSliderTemplate`, and `UIPanelButtonTemplate`.
+- Minimap buttons are commonly implemented by creating a draggable frame anchored to the minimap and persisting a polar position (angle) in saved variables.
+- Interface options panels are registered via `InterfaceOptions_AddCategory` (Classic) or `Settings.OpenToCategory` (Dragonflight+ clients). Classic Era clients still support the former API.
+
+## Combat Log & Aura APIs
+- `UNIT_AURA` events fire when a unit's buffs/debuffs change; Classic Era exposes `AuraUtil.FindAuraByName` / `UnitBuff` to inspect them.
+- `COMBAT_LOG_EVENT_UNFILTERED` returns structured combat log entries; addons call `CombatLogGetCurrentEventInfo()` to unpack details and filter for relevant events (e.g., `SPELL_AURA_APPLIED`).
+- Addons must guard against performance issues by throttling scans, caching state, and filtering units/spell IDs.
+
+## Distribution & Packaging
+- To distribute, authors zip the addon folder (maintaining folder structure) and upload to addon repositories (e.g., CurseForge, Wago). Users extract into `Interface/AddOns/` and enable via the in-game AddOns panel.
+- Interface version numbers in the `.toc` should match the client build to avoid being flagged as out-of-date; Classic Era currently uses `114xx` numbers for Season of Discovery.
+
+## Testing & Debugging Tips
+- `/reload` reloads the UI to pick up code changes and flush saved variables.
+- Use `DEFAULT_CHAT_FRAME:AddMessage`, custom logging utilities, or external tools like BugSack/BugGrabber to monitor errors.
+- Because addons share the global namespace, namespacing (tables, local variables) helps avoid collisions. Libraries like Ace3 provide structured addon frameworks if desired.


### PR DESCRIPTION
## Summary
- document the PotionTracker addon's structure, event flow, UI, and data management in a new repository walkthrough
- add reference notes explaining how World of Warcraft Classic Era addons are packaged, loaded, and interact with the game client

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5ee9b88f08328bd0ffd968b6df194